### PR TITLE
Schemas Added 

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,51 @@ Key goals:
 - Extensibility: modular managers (`client_manager`, `simulation_manager`, `library_manager`) to add new actions/features with minimal coupling.
 - Developer ergonomics: hot-reload Vite UI, simple `uvicorn` server, minimal configuration to get started.
 
+## Schema validation and generation
+
+WOMBAT_ext exposes JSON Schemas for validating configuration and library YAML/JSON files. Schemas are generated programmatically and served via the API.
+
+- **Generator**: `wombat/utilities/schema_gen.py`
+  - Builds JSON Schema (Draft 2020-12) from `attrs`-based models.
+  - Maps Python/typing annotations to schema types; parses Numpy-style docstrings for field descriptions.
+  - Adds simple enums when `attrs.validators.in_(...)` is present.
+  - Provides pragmatic schemas for complex library files (e.g., `turbine`, `substation`, `cable`).
+
+- **API**: `server/routers/schemas.py`
+  - `GET /schemas` — lists available schema names.
+  - `GET /schemas/{name}` — returns a single schema by name.
+  - `GET /schemas/service_equipment/variants` — returns scheduled, unscheduled, and combined variants.
+
+- **Available names** (from `list_schemas()`):
+  - `configuration`
+  - `service_equipment`
+  - `service_equipment/variants`
+  - `service_equipment_scheduled`
+  - `service_equipment_unscheduled`
+  - `substation`
+  - `turbine`
+  - `equipment_turbine`
+  - `cable`
+  - `equipment_cable`
+  - `project_port`
+
+- **Fetch examples**
+  - Single schema: `curl http://127.0.0.1:8000/schemas/turbine`
+  - All names: `curl http://127.0.0.1:8000/schemas`
+  - Service equipment variants: `curl http://127.0.0.1:8000/schemas/service_equipment/variants`
+
+- **Generate in Python**
+  ```python
+  from wombat.utilities.schema_gen import schema_by_name
+
+  turbine_schema = schema_by_name("turbine")
+  config_schema = schema_by_name("configuration")
+  ```
+
+Notes:
+- Schemas are intentionally conservative and focus on structure/types. Some domain constraints may be relaxed for compatibility across libraries.
+- The `configuration` schema specializes `service_equipment` to allow IDs or pairs like `[count, name]` or `[name, count]`.
+
 ## Additions
 
 ### Gantt Chart

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,7 +8,7 @@ import ThemeSelector from './components/ThemeSelector';
 import { ApiProvider, useApiContext } from './context/ApiContext';
 import RestClient from './components/RestClient';
 
-function DownloadWatcher() {
+export function DownloadWatcher() {
   const { pendingDownloadRef, binaryPreviewUrl, csvPreview } = useApiContext();
 
   useEffect(() => {

--- a/client/src/__tests__/App_DownloadWatcher.test.tsx
+++ b/client/src/__tests__/App_DownloadWatcher.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import React from 'react'
+import { ToastProvider } from '../components/ToastManager'
+import { DownloadWatcher } from '../App'
+import { ApiProvider, useApiContext } from '../context/ApiContext'
+
+function TriggerDownload({ kind }: { kind: 'binary' | 'text-html' | 'text-csv' | 'text-yaml' }) {
+  const api = useApiContext()
+  React.useLayoutEffect(() => {
+    api.pendingDownloadRef.current = kind === 'binary' ? 'results/plot.png' : (
+      kind === 'text-html' ? 'results/report.html' : (kind === 'text-csv' ? 'data/export.csv' : 'project/config/base.yaml')
+    )
+    if (kind === 'binary') {
+      api.setBinaryPreviewUrl && api.setBinaryPreviewUrl('blob:already')
+    } else {
+      const map: Record<string, string> = {
+        'text-html': '<h1>hello</h1>',
+        'text-csv': 'a,b\n1,2',
+        'text-yaml': 'a: 1',
+      }
+      api.setCsvPreview(map[kind])
+    }
+  }, [kind])
+  return null
+}
+
+describe('App DownloadWatcher', () => {
+  it('triggers download via anchor for binary preview', async () => {
+    const aClick = vi.fn()
+    const appendChild = vi.fn()
+    const removeChild = vi.fn()
+    const origCreate = document.createElement.bind(document)
+    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: any) => {
+      if (tag === 'a') {
+        const a = origCreate('a') as HTMLAnchorElement
+        // Replace click with spy, keep real DOM element APIs
+        ;(a as any).click = aClick
+        return a as any
+      }
+      return origCreate(tag)
+    })
+    const bodyAppendSpy = vi.spyOn(document.body, 'appendChild').mockImplementation(((el: any) => { appendChild(el); return el }) as any)
+    const bodyRemoveSpy = vi.spyOn(document.body, 'removeChild').mockImplementation(((el: any) => { removeChild(el); return el }) as any)
+
+    render(
+      <ToastProvider>
+        <ApiProvider>
+          <DownloadWatcher />
+          <TriggerDownload kind="binary" />
+        </ApiProvider>
+      </ToastProvider>
+    )
+
+    // Click should have happened for the anchor
+    await waitFor(() => expect(aClick).toHaveBeenCalled())
+    await waitFor(() => expect(appendChild).toHaveBeenCalled())
+    await waitFor(() => expect(removeChild).toHaveBeenCalled())
+
+    createElementSpy.mockRestore()
+    bodyAppendSpy.mockRestore()
+    bodyRemoveSpy.mockRestore()
+  })
+
+  it('creates object URL for text previews and downloads with proper extension', async () => {
+    // jsdom may not provide these; polyfill before spying
+    if (!(URL as any).createObjectURL) {
+      ;(URL as any).createObjectURL = () => 'blob:test'
+    }
+    if (!(URL as any).revokeObjectURL) {
+      ;(URL as any).revokeObjectURL = () => {}
+    }
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+    const aClick = vi.fn()
+    const origCreate = document.createElement.bind(document)
+    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: any) => {
+      if (tag === 'a') {
+        const a = origCreate('a') as HTMLAnchorElement
+        ;(a as any).click = aClick
+        return a as any
+      }
+      return origCreate(tag)
+    })
+
+    render(
+      <ToastProvider>
+        <ApiProvider>
+          <DownloadWatcher />
+          <TriggerDownload kind="text-html" />
+        </ApiProvider>
+      </ToastProvider>
+    )
+
+    await waitFor(() => expect(createObjectURL).toHaveBeenCalled())
+    await waitFor(() => expect(aClick).toHaveBeenCalled())
+    await waitFor(() => expect(revokeObjectURL).toHaveBeenCalled())
+    createElementSpy.mockRestore()
+  })
+})

--- a/client/src/__tests__/CsvPreview.test.tsx
+++ b/client/src/__tests__/CsvPreview.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import CsvPreview from '../components/CsvPreview'
+
+const csv = `name,age,city\nAlice,30,Paris\nBob,25,London\nCharlie,40,New York\n`;
+
+describe('CsvPreview', () => {
+  it('renders table with headers and rows; supports filter and sort', async () => {
+    const user = userEvent.setup()
+    render(<CsvPreview preview={csv} filePath={'people.csv'} />)
+
+    // Title and stats
+    expect(screen.getByText(/CSV Viewer/i)).toBeInTheDocument()
+
+    // Headers derived from first row
+    const ths = screen.getAllByRole('columnheader')
+    expect(ths.map(th => th.textContent?.trim())).toContain('name')
+
+    // Rows
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.getByText('Bob')).toBeInTheDocument()
+
+    // Filter
+    await user.type(screen.getByLabelText(/filter rows/i), 'Alice')
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.queryByText('Bob')).toBeNull()
+
+    // Clear filter and test sort
+    await user.clear(screen.getByLabelText(/filter rows/i))
+    // Click Age header to sort asc then desc
+    const ageIdx = ths.findIndex(th => (th.textContent || '').includes('age'))
+    await user.click(ths[ageIdx]) // asc
+    const rowsAsc = screen.getAllByRole('row').slice(1) // exclude header
+    expect(rowsAsc[0]).toHaveTextContent('Bob')
+    await user.click(ths[ageIdx]) // desc
+    const rowsDesc = screen.getAllByRole('row').slice(1)
+    expect(rowsDesc[0]).toHaveTextContent('Charlie')
+  })
+
+  it('returns null when not CSV or empty', () => {
+    const { container, rerender } = render(<CsvPreview preview={null} filePath={'file.txt'} />)
+    expect(container.firstChild).toBeNull()
+    rerender(<CsvPreview preview={''} filePath={'file.csv'} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/client/src/__tests__/JsonEditor_interactions.test.tsx
+++ b/client/src/__tests__/JsonEditor_interactions.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import JsonEditor, { type JsonObject } from '../components/JsonEditor'
+
+describe('JsonEditor interactions', () => {
+  it('shows empty prompt when no data', () => {
+    render(<JsonEditor data={{} as JsonObject} />)
+    expect(screen.getByText('Open a .yaml file to edit it')).toBeInTheDocument()
+  })
+
+  it('calls onChange for primitive edits and supports boolean/number', () => {
+    const onChange = vi.fn()
+    render(<JsonEditor data={{ a: 1, b: false, c: 'x' }} onChange={onChange} />)
+
+    // number field
+    const num = screen.getByDisplayValue('1') as HTMLInputElement
+    fireEvent.change(num, { target: { value: '2' } })
+    // checkbox
+    const chk = screen.getByRole('checkbox') as HTMLInputElement
+    fireEvent.click(chk)
+    // text
+    const txt = screen.getByDisplayValue('x') as HTMLInputElement
+    fireEvent.change(txt, { target: { value: 'y' } })
+
+    // onChange is debounced via effect, but should have been called >=1 times
+    expect(onChange).toHaveBeenCalled()
+    const last = onChange.mock.lastCall?.[0]
+    expect(last).toMatchObject({ a: 2, b: true, c: 'y' })
+  })
+
+  it('handles array add/remove and onSave', () => {
+    const onChange = vi.fn()
+    const onSave = vi.fn()
+    render(<JsonEditor data={{ arr: ['a'] }} onChange={onChange} onSave={onSave} />)
+
+    // click + to add another item
+    const addBtn = screen.getAllByText('+')[0]
+    fireEvent.click(addBtn)
+
+    // two inputs for arr now
+    const inputs = screen.getAllByRole('textbox') as HTMLInputElement[]
+    expect(inputs.length).toBeGreaterThanOrEqual(2)
+
+    // remove first item by clicking X near first array row button (button with text X)
+    const removeBtn = screen.getAllByText('X')[0]
+    fireEvent.click(removeBtn)
+
+    // Save button should call onSave with current state
+    fireEvent.click(screen.getByText('Save'))
+    expect(onSave).toHaveBeenCalled()
+  })
+})

--- a/client/src/__tests__/ResultsSummary.test.tsx
+++ b/client/src/__tests__/ResultsSummary.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ResultsSummary from '../components/ResultsSummary'
+
+describe('ResultsSummary', () => {
+  it('renders empty state when no data', () => {
+    render(<ResultsSummary />)
+    expect(screen.getByText(/No results yet/i)).toBeInTheDocument()
+  })
+
+  it('renders populated stats and breakdowns', () => {
+    const data = {
+      status: 'finished',
+      results: { events: 1, operations: 2, power_potential: 3, power_production: 4, metrics_input: 5 },
+      stats: {
+        maintenance: {
+          total_requests: 10,
+          start_time: 't0',
+          end_time: 't1',
+          average_requests_per_month: 2.5,
+          peak_month: 'Jan',
+          peak_month_count: 4,
+          requests_by_type: { a: 1, b: 2 },
+          requests_by_component: { x: 3, y: 4 },
+        },
+        power_production: {
+          start_time: 'p0', end_time: 'p1', hours: 100,
+          windfarm_energy_mwh: 123.456, avg_windfarm_power_mw: 1.23, peak_windfarm_power_mw: 9.87,
+          capacity_factor: 0.42,
+          monthly_energy_mwh: { m1: 10, m2: 20 },
+          per_component_energy_mwh: { t1: 5, t2: 6 },
+        },
+      },
+    }
+    render(<ResultsSummary data={data} />)
+    expect(screen.getByText('finished')).toBeInTheDocument()
+    expect(screen.getByText('10')).toBeInTheDocument()
+    expect(screen.getByText('123.46')).toBeInTheDocument()
+    expect(screen.getByText('42.0%')).toBeInTheDocument()
+    expect(screen.getByText(/By type/i)).toBeInTheDocument()
+    expect(screen.getByText(/Top components/i)).toBeInTheDocument()
+  })
+})

--- a/client/src/__tests__/Results_branches.test.tsx
+++ b/client/src/__tests__/Results_branches.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { ApiProvider, useApiContext } from '../context/ApiContext'
+import Results from '../pages/Results'
+import { ToastProvider } from '../components/ToastManager'
+
+function SetupAndRender({ kind }: { kind: 'html' | 'png' }) {
+  const api = useApiContext()
+  // Set up initial state for branch rendering
+  React.useLayoutEffect(() => {
+    // Ensure we don't trigger network calls
+    api.setLibraryFiles({ yaml_files: [], csv_files: [], html_files: kind === 'html' ? ['results\\report.html'] : [], png_files: kind === 'png' ? ['results\\plot.png'] : [], total_files: 1 })
+    if (kind === 'html') {
+      api.setSelectedFile('results\\report.html')
+      api.setCsvPreview('<!doctype html><html><body><h1>Doc</h1></body></html>')
+    } else {
+      api.setSelectedFile('results\\plot.png')
+      api.setBinaryPreviewUrl && api.setBinaryPreviewUrl('blob:mock-url')
+    }
+  }, [kind])
+  return <Results />
+}
+
+describe('Results page conditional rendering', () => {
+  beforeEach(() => {
+    // Reset DOM state
+    document.body.innerHTML = ''
+  })
+
+  it('renders HTML branch with iframe', async () => {
+    render(
+      <ToastProvider>
+        <ApiProvider>
+          <SetupAndRender kind="html" />
+        </ApiProvider>
+      </ToastProvider>
+    )
+    // iframe is rendered with title of the selected file
+    const iframe = await screen.findByTitle('results\\report.html')
+    expect(iframe.tagName.toLowerCase()).toBe('iframe')
+  })
+
+  it('renders PNG branch with image', async () => {
+    render(
+      <ToastProvider>
+        <ApiProvider>
+          <SetupAndRender kind="png" />
+        </ApiProvider>
+      </ToastProvider>
+    )
+    const img = await screen.findByAltText(/Image preview: results\\plot\.png/i)
+    expect((img as HTMLImageElement).src).toContain('blob:mock-url')
+  })
+})

--- a/client/src/__tests__/SimulationManager.interactions.test.tsx
+++ b/client/src/__tests__/SimulationManager.interactions.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ToastProvider } from '../components/ToastManager'

--- a/client/src/__tests__/SimulationManager.interactions.test.tsx
+++ b/client/src/__tests__/SimulationManager.interactions.test.tsx
@@ -1,0 +1,221 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { ToastProvider } from '../components/ToastManager'
+import SimulationManager from '../pages/SimulationManager'
+
+// Mock useToasts to observe calls
+vi.mock('../hooks/useToasts', () => {
+  return {
+    useToasts: () => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      success: vi.fn(),
+      simulation: vi.fn(),
+      tempSweep: vi.fn(),
+    }),
+  }
+})
+
+// Mock child components to simple test doubles for targeted interactions
+vi.mock('../components/SimulationControls', () => {
+  return {
+    default: ({ onRun, onGetConfig, onClearTemp, onGetLibraryFiles, onSaveLibrary }: any) => (
+      <div>
+        <button data-testid="btn-run" onClick={onRun}>run</button>
+        <button data-testid="btn-get-config" onClick={onGetConfig}>get-config</button>
+        <button data-testid="btn-clear-temp" onClick={onClearTemp}>clear-temp</button>
+        <button data-testid="btn-get-lib" onClick={onGetLibraryFiles}>get-lib</button>
+        <button data-testid="btn-save-lib" onClick={onSaveLibrary}>save-lib</button>
+      </div>
+    )
+  }
+})
+
+vi.mock('../components/LibraryPanel', () => {
+  return {
+    default: ({ onFileSelect, onAddFile, onDeleteFile, onReplaceFile, onDownloadFile }: any) => (
+      <div>
+        <button data-testid="select-file" onClick={() => onFileSelect('project\\config\\base.yaml')}>select-file</button>
+        <button data-testid="add-file" onClick={() => onAddFile('new.yaml', { a: 1 })}>add-file</button>
+        <button data-testid="delete-file" onClick={() => onDeleteFile('project\\config\\base.yaml')}>delete-file</button>
+        <button data-testid="replace-file" onClick={() => onReplaceFile('project\\config\\base.yaml')}>replace-file</button>
+        <button data-testid="download-file" onClick={() => onDownloadFile('project\\config\\base.yaml')}>download-file</button>
+      </div>
+    )
+  }
+})
+
+vi.mock('../components/CsvPreview', () => ({
+  default: () => <div data-testid="csv-preview" />
+}))
+
+// Mock ApiContext to control state and observe calls
+const spies = {
+  setSelectedSavedLibrary: vi.fn(),
+  setSelectedFile: vi.fn(),
+  setConfigData: vi.fn(),
+  setCsvPreview: vi.fn(),
+  readFile: vi.fn(async () => {}),
+  addOrReplaceFile: vi.fn(async () => {}),
+  deleteFile: vi.fn(async () => {}),
+  getConfig: vi.fn(async () => {}),
+  runSimulation: vi.fn(async () => {}),
+  fetchLibraryFiles: vi.fn(async () => {}),
+  saveLibrary: vi.fn(async () => {}),
+  loadSaved: vi.fn(async () => {}),
+  deleteSaved: vi.fn(async () => {}),
+  sweepTemp: vi.fn(async () => 1),
+}
+
+vi.mock('../context/ApiContext', async (importOriginal) => {
+  const mod = await importOriginal<any>()
+  return {
+    ...mod,
+    useApiContext: () => ({
+      apiBaseUrl: 'http://x', setApiBaseUrl: vi.fn(),
+      sessionId: 'mock-123', initSession: vi.fn(), endSession: vi.fn(),
+
+      libraryFiles: { yaml_files: ['project\\config\\base.yaml'], csv_files: [], total_files: 1 },
+      setLibraryFiles: vi.fn(),
+      savedLibraries: ['lib1', 'lib2'],
+      setSavedLibraries: vi.fn(),
+      selectedSavedLibrary: 'lib1',
+      setSelectedSavedLibrary: spies.setSelectedSavedLibrary,
+      selectedFile: 'project\\config\\base.yaml',
+      setSelectedFile: spies.setSelectedFile,
+      configData: {},
+      setConfigData: spies.setConfigData,
+      csvPreview: null,
+      setCsvPreview: spies.setCsvPreview,
+      binaryPreviewUrl: null,
+      setBinaryPreviewUrl: vi.fn(),
+      pendingDownloadRef: { current: null },
+
+      results: null, setResults: vi.fn(),
+
+      refreshAll: vi.fn(async () => {}),
+      getConfig: spies.getConfig,
+      fetchLibraryFiles: spies.fetchLibraryFiles,
+      fetchSavedLibraries: vi.fn(async () => {}),
+      readFile: spies.readFile,
+      addOrReplaceFile: spies.addOrReplaceFile,
+      deleteFile: spies.deleteFile,
+      saveLibrary: spies.saveLibrary,
+      loadSaved: spies.loadSaved,
+      deleteSaved: spies.deleteSaved,
+      runSimulation: spies.runSimulation,
+      clearClientTemp: vi.fn(async () => true),
+      sweepTemp: spies.sweepTemp,
+      sweepTempAll: vi.fn(async () => 0),
+    })
+  }
+})
+
+beforeEach(() => {
+  Object.values(spies).forEach((fn) => (fn as any).mockClear?.())
+})
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <SimulationManager />
+    </ToastProvider>
+  )
+}
+
+describe('SimulationManager interactions', () => {
+  it('triggers simulation controls actions', async () => {
+    renderPage()
+    fireEvent.click(screen.getByTestId('btn-run'))
+    fireEvent.click(screen.getByTestId('btn-get-config'))
+    fireEvent.click(screen.getByTestId('btn-clear-temp'))
+    fireEvent.click(screen.getByTestId('btn-get-lib'))
+
+    await waitFor(() => {
+      expect(spies.runSimulation).toHaveBeenCalled()
+      expect(spies.getConfig).toHaveBeenCalled()
+      expect(spies.sweepTemp).toHaveBeenCalled()
+      expect(spies.fetchLibraryFiles).toHaveBeenCalled()
+    })
+  })
+
+  it('handles save library prompt cancel and success paths', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt')
+
+    // Cancel path
+    promptSpy.mockReturnValueOnce(null as any)
+    renderPage()
+    fireEvent.click(screen.getByTestId('btn-save-lib'))
+    await waitFor(() => {
+      expect(spies.saveLibrary).not.toHaveBeenCalled()
+    })
+
+    // Success path
+    promptSpy.mockReturnValueOnce('myproj')
+    fireEvent.click(screen.getByTestId('btn-save-lib'))
+    await waitFor(() => {
+      expect(spies.saveLibrary).toHaveBeenCalledWith('myproj')
+    })
+
+    promptSpy.mockRestore()
+  })
+
+  it('handles library panel actions and updates state', async () => {
+    renderPage()
+    // select file -> clears previews, sets selection and reads
+    fireEvent.click(screen.getByTestId('select-file'))
+    await waitFor(() => {
+      expect(spies.setSelectedFile).toHaveBeenCalled()
+      expect(spies.setCsvPreview).toHaveBeenCalledWith(null)
+      expect(spies.setConfigData).toHaveBeenCalled()
+      expect(spies.readFile).toHaveBeenCalled()
+    })
+
+    // download triggers raw read and sets pending
+    fireEvent.click(screen.getByTestId('download-file'))
+    await waitFor(() => {
+      expect(spies.readFile).toHaveBeenCalled()
+    })
+
+    // replace uses input + click; we cannot simulate File API here, but handler is invoked
+    fireEvent.click(screen.getByTestId('replace-file'))
+    // delete file path
+    fireEvent.click(screen.getByTestId('delete-file'))
+    await waitFor(() => {
+      expect(spies.deleteFile).toHaveBeenCalled()
+    })
+  })
+
+  it('handles saved libraries change and delete branches', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm')
+
+    renderPage()
+
+    // Change selection to lib2 -> triggers loadSaved through SavedLibrariesBar onChange
+    const select = screen.getByRole('combobox')
+    fireEvent.change(select, { target: { value: 'lib2' } })
+    await waitFor(() => {
+      expect(spies.setSelectedSavedLibrary).toHaveBeenCalledWith('lib2')
+      expect(spies.loadSaved).toHaveBeenCalledWith('lib2')
+    })
+
+    // Delete cancel path
+    confirmSpy.mockReturnValueOnce(false)
+    const deleteBtn = screen.getByRole('button', { name: /Delete saved library/i })
+    fireEvent.click(deleteBtn)
+    await waitFor(() => {
+      expect(spies.deleteSaved).not.toHaveBeenCalled()
+    })
+
+    // Delete confirm path
+    confirmSpy.mockReturnValueOnce(true)
+    fireEvent.click(deleteBtn)
+    await waitFor(() => {
+      expect(spies.deleteSaved).toHaveBeenCalled()
+      expect(spies.setSelectedSavedLibrary).toHaveBeenCalledWith('')
+    })
+
+    confirmSpy.mockRestore()
+  })
+})

--- a/client/src/__tests__/YamlJsonViewer.test.tsx
+++ b/client/src/__tests__/YamlJsonViewer.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import YamlJsonViewer from '../components/YamlJsonViewer'
+
+describe('YamlJsonViewer', () => {
+  it('renders No content for null or empty object', () => {
+    const { rerender } = render(<YamlJsonViewer data={null} title="T" />)
+    expect(screen.getByText('No content.')).toBeInTheDocument()
+
+    rerender(<YamlJsonViewer data={{}} title="T" />)
+    expect(screen.getByText('No content.')).toBeInTheDocument()
+  })
+
+  it('renders string payload in pre block', () => {
+    render(<YamlJsonViewer data={'hello'} title="T" />)
+    expect(screen.getByText('hello')).toBeInTheDocument()
+  })
+
+  it('renders object tree', () => {
+    render(<YamlJsonViewer data={{ a: 1, b: 'x' }} title="Obj" />)
+    expect(screen.getByText('Obj')).toBeInTheDocument()
+    expect(screen.getByText('a')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+    expect(screen.getByText('b')).toBeInTheDocument()
+    expect(screen.getByText('x')).toBeInTheDocument()
+  })
+
+  it('renders array tree', () => {
+    render(<YamlJsonViewer data={{ arr: [1, 2, 3] }} title="Arr" />)
+    expect(screen.getByText('Arr')).toBeInTheDocument()
+    expect(screen.getByText('[0]')).toBeInTheDocument()
+    expect(screen.getByText('[1]')).toBeInTheDocument()
+    expect(screen.getByText('[2]')).toBeInTheDocument()
+  })
+})

--- a/client/src/__tests__/main.test.tsx
+++ b/client/src/__tests__/main.test.tsx
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Ensure a #root exists for main.tsx to mount into
+beforeEach(() => {
+  document.body.innerHTML = '<div id="root"></div>'
+})
+
+describe('main.tsx bootstrap', () => {
+  it('creates a root and renders App without throwing', async () => {
+    // Mock createRoot to avoid actually rendering React tree in this unit test
+    vi.doMock('react-dom/client', async (orig) => {
+      const mod: any = await orig()
+      return {
+        ...mod,
+        createRoot: vi.fn(() => ({ render: vi.fn() })),
+      }
+    })
+
+    // Dynamic import after mocks are set up
+    await import('../main')
+
+    // Assert root element is present
+    const root = document.getElementById('root')
+    expect(root).toBeTruthy()
+  })
+})

--- a/client/src/__tests__/mockApiClient.test.ts
+++ b/client/src/__tests__/mockApiClient.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { WorkerResponse } from '../workers/mockApiWorker'
+import * as workerModule from '../workers/mockApiWorker'
+
+// Helper to import fresh module each test
+async function importClient() {
+  const mod = await import('../workers/mockApiClient')
+  return mod
+}
+
+describe('mockApiClient request paths', () => {
+  const realWorker = (globalThis as any).Worker
+
+  afterEach(() => {
+    ;(globalThis as any).Worker = realWorker
+    vi.restoreAllMocks()
+  })
+
+  it('falls back to direct handler when Worker is undefined', async () => {
+    ;(globalThis as any).Worker = undefined
+    const { mockApiRequest } = await importClient()
+
+    const res = await mockApiRequest('POST', '/api/session')
+    expect(res.ok).toBe(true)
+    const cid = String(res.json?.client_id || '')
+    expect(cid).toMatch(/^mock-/)
+
+    const res2 = await mockApiRequest('GET', `/api/${cid}/refresh`)
+    expect(res2.ok).toBe(true)
+    expect(res2.json?.files).toBeTruthy()
+  })
+
+  it('uses Worker path when Worker is available', async () => {
+    // Minimal stub Worker that routes to handleWorkerRequest and invokes message listeners
+    class StubWorker {
+      private listeners = new Map<string, Function[]>()
+      constructor(_url: any, _opts: any) {}
+      addEventListener(type: string, cb: any) {
+        const arr = this.listeners.get(type) || []
+        arr.push(cb)
+        this.listeners.set(type, arr)
+      }
+      postMessage = async (msg: any) => {
+        try {
+          const res: WorkerResponse = await workerModule.handleWorkerRequest(msg)
+          const ls = this.listeners.get('message') || []
+          ls.forEach((fn) => fn({ data: res }))
+        } catch (e) {
+          const ls = this.listeners.get('error') || []
+          ls.forEach((fn) => fn(e))
+        }
+      }
+    }
+    ;(globalThis as any).Worker = StubWorker as unknown as Worker
+
+    const { mockApiRequest, startMockApi } = await importClient()
+
+    // ensureWorker gets initialized
+    startMockApi()
+
+    const res = await mockApiRequest('POST', '/api/session')
+    expect(res.ok).toBe(true)
+    const cid = String(res.json?.client_id || '')
+    expect(cid).toMatch(/^mock-/)
+
+    const res2 = await mockApiRequest('GET', `/api/${cid}/library/files`)
+    expect(res2.ok).toBe(true)
+    expect(res2.json?.total_files).toBeGreaterThan(0)
+  })
+})

--- a/client/src/__tests__/useLibrary_actions.test.tsx
+++ b/client/src/__tests__/useLibrary_actions.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { ApiProvider, useApiContext } from '../context/ApiContext'
+import { ToastProvider } from '../components/ToastManager'
+
+function Harness() {
+  const api = useApiContext()
+  return (
+    <div>
+      <button onClick={api.initSession}>init</button>
+      <div data-testid="sid">{api.sessionId || ''}</div>
+      <button onClick={api.fetchSavedLibraries}>fetchSaved</button>
+      <button onClick={api.fetchLibraryFiles}>fetchFiles</button>
+      <button onClick={api.getConfig}>getConfig</button>
+      <button onClick={() => api.addOrReplaceFile('project\\config\\new.yaml', { a: 1 })}>addFile</button>
+      <button onClick={() => api.deleteFile('project\\config\\new.yaml')}>delFile</button>
+      <button onClick={() => api.saveLibrary('example')}>saveLib</button>
+      <button onClick={() => api.loadSaved('example')}>loadSaved</button>
+      <button onClick={() => api.deleteSaved('example')}>deleteSaved</button>
+      <div data-testid="saved">{(api.savedLibraries || []).join(',')}</div>
+      <div data-testid="files">{String(!!api.libraryFiles)}</div>
+      <div data-testid="cfg">{String(Object.keys(api.configData || {}).length > 0)}</div>
+      <div data-testid="sel">{api.selectedFile}</div>
+    </div>
+  )
+}
+
+describe('useLibrary actions', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    // Force server fetches to fail to exercise worker fallbacks
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('down', { status: 503 })) as any)
+  })
+
+  it('covers saved libraries, files, config, and file ops via worker fallback', async () => {
+    render(
+      <ToastProvider>
+        <ApiProvider>
+          <Harness />
+        </ApiProvider>
+      </ToastProvider>
+    )
+
+    // init session -> mock-*
+    screen.getByText('init').click()
+    await waitFor(() => expect(screen.getByTestId('sid').textContent).toMatch(/^mock-/))
+
+    // fetch saved (initial mock list)
+    screen.getByText('fetchSaved').click()
+    await waitFor(() => expect(screen.getByTestId('saved').textContent).toMatch(/dinwoodie_/))
+
+    // fetch files
+    screen.getByText('fetchFiles').click()
+    await waitFor(() => expect(screen.getByTestId('files').textContent).toBe('true'))
+
+    // get config
+    screen.getByText('getConfig').click()
+    await waitFor(() => expect(screen.getByTestId('cfg').textContent).toBe('true'))
+
+    // add file -> should not throw and files truthy remains
+    screen.getByText('addFile').click()
+    await waitFor(() => expect(screen.getByTestId('files').textContent).toBe('true'))
+
+    // delete file
+    screen.getByText('delFile').click()
+    await waitFor(() => expect(screen.getByTestId('files').textContent).toBe('true'))
+
+    // save library (also refresh saved) -> adds 'example'
+    screen.getByText('saveLib').click()
+    await waitFor(() => expect(screen.getByTestId('saved').textContent).toContain('example'))
+
+    // load saved -> selects base.yaml and reads it
+    screen.getByText('loadSaved').click()
+    await waitFor(() => expect(screen.getByTestId('sel').textContent).toBe('project\\config\\base.yaml'))
+
+    // delete saved -> removed from list
+    screen.getByText('deleteSaved').click()
+    await waitFor(() => expect(screen.getByTestId('saved').textContent).not.toContain('example'))
+  })
+})

--- a/client/src/__tests__/useLibrary_readFile.test.tsx
+++ b/client/src/__tests__/useLibrary_readFile.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { ToastProvider } from '../components/ToastManager'
+import { ApiProvider, useApiContext } from '../context/ApiContext'
+import React from 'react'
+
+function Harness() {
+  const api = useApiContext()
+  return (
+    <div>
+      <button onClick={api.initSession}>init</button>
+      <div data-testid="session">{api.sessionId || ''}</div>
+      <button onClick={() => api.readFile('results\\plot.png', true)}>readPng</button>
+      <button onClick={() => api.readFile('results\\report.html', true)}>readHtml</button>
+      <button onClick={() => api.readFile('project\\config\\base.yaml', false)}>readYaml</button>
+      <div data-testid="bin">{String(api.binaryPreviewUrl ?? '')}</div>
+      <div data-testid="csv">{String(api.csvPreview ?? '')}</div>
+      <div data-testid="cfg">{String(!!api.configData && Object.keys(api.configData).length > 0)}</div>
+      <div data-testid="sel">{api.selectedFile}</div>
+    </div>
+  )
+}
+
+describe('useLibrary.readFile', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    // Force server fetch to fail to use worker
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('down', { status: 503 })) as any)
+    // jsdom doesn't implement createObjectURL; mock it
+    const g: any = globalThis as any
+    if (!g.URL) g.URL = {} as any
+    if (!g.URL.createObjectURL) g.URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+    if (!g.URL.revokeObjectURL) g.URL.revokeObjectURL = vi.fn()
+  })
+
+  it('handles binary, raw text, and yaml paths', async () => {
+    render(
+      <ToastProvider>
+        <ApiProvider>
+          <Harness />
+        </ApiProvider>
+      </ToastProvider>
+    )
+
+    // Init mock session
+    screen.getByText('init').click()
+    await waitFor(() => expect(screen.getByTestId('session').textContent).toMatch(/^mock-/))
+
+    // Read PNG (raw binary)
+    screen.getByText('readPng').click()
+    await waitFor(() => expect(screen.getByTestId('bin').textContent).toBe('blob:mock-url'))
+
+    // Read HTML (raw text)
+    screen.getByText('readHtml').click()
+    await waitFor(() => expect(screen.getByTestId('csv').textContent).toContain('<!doctype html>'))
+
+    // Read YAML (parsed)
+    screen.getByText('readYaml').click()
+    await waitFor(() => expect(screen.getByTestId('cfg').textContent).toBe('true'))
+    await waitFor(() => expect(screen.getByTestId('sel').textContent).toBe('project\\config\\base.yaml'))
+  })
+})

--- a/client/src/__tests__/useLibrary_readFile.test.tsx
+++ b/client/src/__tests__/useLibrary_readFile.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { ToastProvider } from '../components/ToastManager'
 import { ApiProvider, useApiContext } from '../context/ApiContext'
-import React from 'react'
 
 function Harness() {
   const api = useApiContext()

--- a/client/src/__tests__/useSession.test.tsx
+++ b/client/src/__tests__/useSession.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { ToastProvider } from '../components/ToastManager'
+import { useSession } from '../hooks/useSession'
+import React from 'react'
+
+function Harness({ onReady }: { onReady: (api: ReturnType<typeof useSession>) => void }) {
+  const api = useSession('http://127.0.0.1:8000/api')
+  React.useEffect(() => { onReady(api) }, [api, onReady])
+  return null
+}
+
+describe('useSession', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('requireSession throws without session; initSession sets an id; endSession clears', async () => {
+    // Mock REST endpoints directly for stability
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/session') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ client_id: 'abc123' }), { status: 200 })
+      }
+      if (url.includes('/session/') && init?.method === 'DELETE') {
+        return new Response(JSON.stringify({ status: 'ended' }), { status: 200 })
+      }
+      return new Response('not mocked', { status: 404 })
+    }) as any)
+
+    let apiRef: ReturnType<typeof useSession> | null = null
+    render(
+      <ToastProvider>
+        <Harness onReady={(api) => { apiRef = api }} />
+      </ToastProvider>
+    )
+
+    expect(apiRef).toBeTruthy()
+    const api = apiRef!
+
+    // requireSession should throw before init
+    expect(() => api.requireSession()).toThrowError(/No REST session/i)
+
+    // initSession should set some session id (REST or mock fallback)
+    const id = await api.initSession()
+    expect(String(id)).not.toBe('')
+    // Wait for state to flush so requireSession stops throwing
+    await import('@testing-library/react').then(({ waitFor }) =>
+      waitFor(() => expect(() => api.requireSession()).not.toThrow())
+    )
+    // requireSession should now return an id equal to the stored session
+    const reqId = api.requireSession()
+    expect(String(reqId)).not.toBe('')
+
+    // endSession should clear sessionId even if server delete fails
+    await api.endSession()
+    expect(api.sessionId).toBeNull()
+
+    // Then calling requireSession again throws
+    expect(() => api.requireSession()).toThrowError()
+  })
+})

--- a/client/src/__tests__/useSimulation.test.tsx
+++ b/client/src/__tests__/useSimulation.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { ToastProvider } from '../components/ToastManager'
 import { ApiProvider, useApiContext } from '../context/ApiContext'
-import React from 'react'
 
 function Harness() {
   const api = useApiContext()

--- a/client/src/__tests__/useSimulation.test.tsx
+++ b/client/src/__tests__/useSimulation.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { ToastProvider } from '../components/ToastManager'
+import { ApiProvider, useApiContext } from '../context/ApiContext'
+import React from 'react'
+
+function Harness() {
+  const api = useApiContext()
+  return (
+    <div>
+      <button onClick={api.initSession}>init</button>
+      <button onClick={api.runSimulation}>run</button>
+      <div data-testid="session">{api.sessionId || ''}</div>
+      <div data-testid="total">{api.libraryFiles?.total_files ?? 0}</div>
+      <div data-testid="results">{String(!!api.results)}</div>
+    </div>
+  )
+}
+
+describe('useSimulation worker fallback', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    // Force REST simulate trigger + status to fail so we hit worker paths
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('down', { status: 503 })) as any)
+  })
+
+  it('uses mock worker and sets results and files', async () => {
+    render(
+      <ToastProvider>
+        <ApiProvider>
+          <Harness />
+        </ApiProvider>
+      </ToastProvider>
+    )
+
+    screen.getByText('init').click()
+    await waitFor(() => expect(screen.getByTestId('session').textContent).toMatch(/^mock-/))
+    screen.getByText('run').click()
+
+    await waitFor(() => expect(screen.getByTestId('results').textContent).toBe('true'), { timeout: 5000 })
+    await waitFor(() => expect(Number(screen.getByTestId('total').textContent)).toBeGreaterThan(0), { timeout: 5000 })
+  })
+})

--- a/client/src/__tests__/useTemp.test.tsx
+++ b/client/src/__tests__/useTemp.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ApiProvider, useApiContext } from '../context/ApiContext'
+import { ToastProvider } from '../components/ToastManager'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+function TempHarness() {
+  const api = useApiContext()
+  return (
+    <div>
+      <button onClick={api.initSession}>init</button>
+      <div data-testid="sid">{api.sessionId || ''}</div>
+      <button onClick={async () => {
+        const ok = await api.clearClientTemp()
+        ;(window as any).__ok = ok
+      }}>clearClientTemp</button>
+      <button onClick={async () => {
+        const c = await api.sweepTemp()
+        ;(window as any).__count1 = c
+      }}>sweepTemp</button>
+      <button onClick={async () => {
+        const c = await api.sweepTempAll()
+        ;(window as any).__count2 = c
+      }}>sweepTempAll</button>
+    </div>
+  )
+}
+
+describe('useTemp hook', () => {
+  const realFetch = globalThis.fetch
+  beforeEach(() => {
+    ;(globalThis as any).fetch = vi.fn(async (url: string, opts?: any) => {
+      const u = String(url)
+      if (u.includes('/api/session') && (!opts || opts.method === 'POST')) {
+        return new Response(JSON.stringify({ client_id: 'mock-xyz' }), { status: 200 })
+      }
+      if (u.endsWith('/temp') && opts?.method === 'DELETE') {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 })
+      }
+      if (u.endsWith('/temp/sweep') && opts?.method === 'POST') {
+        return new Response(JSON.stringify({ removed: ['a', 'b'] }), { status: 200 })
+      }
+      if (u.endsWith('/temp/sweep_all') && opts?.method === 'POST') {
+        return new Response(JSON.stringify({ removed: ['a'] }), { status: 200 })
+      }
+      // default
+      return new Response('not found', { status: 404 })
+    })
+  })
+  afterEach(() => {
+    ;(globalThis as any).fetch = realFetch
+  })
+
+  it('performs clearClientTemp, sweepTemp, sweepTempAll', async () => {
+    render(
+      <ToastProvider>
+        <ApiProvider>
+          <TempHarness />
+        </ApiProvider>
+      </ToastProvider>
+    )
+    // init
+    fireEvent.click(screen.getByText('init'))
+    await waitFor(() => expect(screen.getByTestId('sid').textContent).toMatch(/^mock-/))
+    // clear
+    await (async () => fireEvent.click(screen.getByText('clearClientTemp')))()
+    await waitFor(() => expect((window as any).__ok).toBe(true))
+    // sweep
+    await (async () => fireEvent.click(screen.getByText('sweepTemp')))()
+    await waitFor(() => expect((window as any).__count1).toBe(2))
+    // sweep all
+    await (async () => fireEvent.click(screen.getByText('sweepTempAll')))()
+    await waitFor(() => expect((window as any).__count2).toBe(1))
+  })
+})

--- a/client/src/__tests__/useToasts.test.tsx
+++ b/client/src/__tests__/useToasts.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ToastProvider } from '../components/ToastManager'
+import { useToasts } from '../hooks/useToasts'
+
+// Mock react-toastify.promise to observe calls
+vi.mock('react-toastify', async (importOriginal) => {
+  const orig: any = await importOriginal()
+  return {
+    ...orig,
+    promise: vi.fn((p: Promise<any>, _msgs: any) => p),
+  }
+})
+
+function Harness() {
+  const { info, success, warning, error, promise, simulation, tempSweep } = useToasts()
+  return (
+    <div>
+      <button onClick={() => info('i')}>i</button>
+      <button onClick={() => success('s')}>s</button>
+      <button onClick={() => warning('w')}>w</button>
+      <button onClick={() => error('e')}>e</button>
+      <button onClick={() => promise(Promise.resolve(1), { pending: 'p', success: 'ok', error: 'err' })}>p</button>
+      <button onClick={() => simulation(Promise.resolve(1))}>sim</button>
+      <button onClick={() => tempSweep(Promise.resolve(2))}>sweep</button>
+    </div>
+  )
+}
+
+describe('useToasts', () => {
+  it('wires helpers and promise/simulation/tempSweep', async () => {
+    render(
+      <ToastProvider>
+        <Harness />
+      </ToastProvider>
+    )
+
+    fireEvent.click(screen.getByText('i'))
+    fireEvent.click(screen.getByText('s'))
+    fireEvent.click(screen.getByText('w'))
+    fireEvent.click(screen.getByText('e'))
+    fireEvent.click(screen.getByText('p'))
+    fireEvent.click(screen.getByText('sim'))
+    fireEvent.click(screen.getByText('sweep'))
+
+    // Basic assertion that code paths executed without throwing
+    expect(true).toBe(true)
+  })
+})

--- a/client/src/components/EditorPanel.tsx
+++ b/client/src/components/EditorPanel.tsx
@@ -1,4 +1,6 @@
 import JsonEditor, { type JsonObject } from './JsonEditor'
+import { useEffect, useState } from 'react'
+import { useApiContext } from '../context/ApiContext'
 
 export type EditorPanelProps = {
   data: JsonObject
@@ -7,11 +9,39 @@ export type EditorPanelProps = {
 }
 
 export default function EditorPanel({ data, onChange, onSave }: EditorPanelProps) {
+  const { selectedFile, getSchema } = useApiContext()
+  const [schema, setSchema] = useState<any | null>(null)
+
+  useEffect(() => {
+    let active = true
+    const file = (selectedFile || '').toLowerCase()
+    // minimally: fetch configuration schema for YAML files
+    if (file.endsWith('.yaml') || file.endsWith('.yml')) {
+      const schemaName = (file.includes('vessel') || file.includes('service_equipment'))
+        ? 'service_equipment'
+        : 'configuration'
+      getSchema(schemaName)
+        .then((s) => { if (active) setSchema(s) })
+        .catch(() => { if (active) setSchema(null) })
+    } else {
+      // If no selectedFile yet but data is present (autoloaded base config), fetch configuration schema
+      if (data && Object.keys(data || {}).length > 0) {
+        getSchema('configuration')
+          .then((s) => { if (active) setSchema(s) })
+          .catch(() => { if (active) setSchema(null) })
+      } else {
+        setSchema(null)
+      }
+    }
+    return () => { active = false }
+  }, [selectedFile, data, getSchema])
+
   return (
     <div className="col">
       <div className="editor-wrap">
         <JsonEditor
           data={data}
+          schema={schema || undefined}
           onChange={(newData) => onChange(newData as JsonObject)}
           onSave={(newData) => onSave(newData as JsonObject)}
         />

--- a/client/src/components/EditorPanel.tsx
+++ b/client/src/components/EditorPanel.tsx
@@ -18,8 +18,8 @@ export default function EditorPanel({ data, onChange, onSave }: EditorPanelProps
     // minimally: fetch configuration schema for YAML files
     if (file.endsWith('.yaml') || file.endsWith('.yml')) {
       const isVessel = file.includes('vessels') || file.includes('vessel') || file.includes('service_equipment')
+      const isPort = file.includes('project/port') || (file.includes('project') && file.includes('port'))
       if (isVessel) {
-        console.log(data)
         const strategy = (data as any)?.strategy
         const strat = typeof strategy === 'string' ? strategy.toLowerCase() : ''
         const isUnscheduled = strat === 'unscheduled' || strat === 'requests' || strat === 'downtime'
@@ -29,6 +29,10 @@ export default function EditorPanel({ data, onChange, onSave }: EditorPanelProps
             ? 'service_equipment_unscheduled'
             : 'service_equipment'
         getSchema(schemaName)
+          .then((s) => { if (active) setSchema(s) })
+          .catch(() => { if (active) setSchema(null) })
+      } else if (isPort) {
+        getSchema('project_port')
           .then((s) => { if (active) setSchema(s) })
           .catch(() => { if (active) setSchema(null) })
       } else {

--- a/client/src/components/EditorPanel.tsx
+++ b/client/src/components/EditorPanel.tsx
@@ -19,6 +19,7 @@ export default function EditorPanel({ data, onChange, onSave }: EditorPanelProps
     if (file.endsWith('.yaml') || file.endsWith('.yml')) {
       const isVessel = file.includes('vessels') || file.includes('vessel') || file.includes('service_equipment')
       const isSubstation = file.includes('substation')
+      const isTurbine = file.includes('turbine')
       const isPort = (
         file.includes('project/port') ||
         file.includes('project\\port') ||
@@ -43,6 +44,22 @@ export default function EditorPanel({ data, onChange, onSave }: EditorPanelProps
           .catch(() => {
             // Fallback: use combined service_equipment schema
             getSchema('service_equipment')
+              .then((s) => { if (active) setSchema(s) })
+              .catch(() => { if (active) setSchema(null) })
+          })
+      } else if (isTurbine) {
+        // Turbine schema support; prefer wrapper when YAML has top-level capacity/capex or nested turbine object
+        const hasWrapper = !!data && typeof data === 'object' && (
+          Object.prototype.hasOwnProperty.call(data as any, 'turbine') ||
+          Object.prototype.hasOwnProperty.call(data as any, 'capacity_kw') ||
+          Object.prototype.hasOwnProperty.call(data as any, 'capex_kw')
+        )
+        const name = hasWrapper ? 'equipment_turbine' : 'turbine'
+        getSchema(name)
+          .then((s) => { if (active) setSchema(s) })
+          .catch(() => {
+            const fallback = hasWrapper ? 'turbine' : 'configuration'
+            getSchema(fallback)
               .then((s) => { if (active) setSchema(s) })
               .catch(() => { if (active) setSchema(null) })
           })

--- a/client/src/components/EditorPanel.tsx
+++ b/client/src/components/EditorPanel.tsx
@@ -17,12 +17,23 @@ export default function EditorPanel({ data, onChange, onSave }: EditorPanelProps
     const file = (selectedFile || '').toLowerCase()
     // minimally: fetch configuration schema for YAML files
     if (file.endsWith('.yaml') || file.endsWith('.yml')) {
-      const schemaName = (file.includes('vessel') || file.includes('service_equipment'))
-        ? 'service_equipment'
-        : 'configuration'
-      getSchema(schemaName)
-        .then((s) => { if (active) setSchema(s) })
-        .catch(() => { if (active) setSchema(null) })
+      const isVessel = file.includes('vessels') || file.includes('vessel') || file.includes('service_equipment')
+      if (isVessel) {
+        const strategy = (data as any)?.strategy
+        const strat = typeof strategy === 'string' ? strategy.toLowerCase() : ''
+        const schemaName = strat === 'scheduled'
+          ? 'service_equipment_scheduled'
+          : strat === 'unscheduled'
+            ? 'service_equipment_unscheduled'
+            : 'service_equipment'
+        getSchema(schemaName)
+          .then((s) => { if (active) setSchema(s) })
+          .catch(() => { if (active) setSchema(null) })
+      } else {
+        getSchema('configuration')
+          .then((s) => { if (active) setSchema(s) })
+          .catch(() => { if (active) setSchema(null) })
+      }
     } else {
       // If no selectedFile yet but data is present (autoloaded base config), fetch configuration schema
       if (data && Object.keys(data || {}).length > 0) {

--- a/client/src/components/EditorPanel.tsx
+++ b/client/src/components/EditorPanel.tsx
@@ -18,7 +18,12 @@ export default function EditorPanel({ data, onChange, onSave }: EditorPanelProps
     // minimally: fetch configuration schema for YAML files
     if (file.endsWith('.yaml') || file.endsWith('.yml')) {
       const isVessel = file.includes('vessels') || file.includes('vessel') || file.includes('service_equipment')
-      const isPort = file.includes('project/port') || (file.includes('project') && file.includes('port'))
+      const isSubstation = file.includes('substation')
+      const isPort = (
+        file.includes('project/port') ||
+        file.includes('project\\port') ||
+        (file.includes('project') && file.includes('port'))
+      )
       if (isVessel) {
         const strategy = (data as any)?.strategy
         const strat = typeof strategy === 'string' ? strategy.toLowerCase() : ''
@@ -31,6 +36,16 @@ export default function EditorPanel({ data, onChange, onSave }: EditorPanelProps
         getSchema(schemaName)
           .then((s) => { if (active) setSchema(s) })
           .catch(() => { if (active) setSchema(null) })
+      } else if (isSubstation) {
+        // Use dedicated substation schema for substation YAMLs
+        getSchema('substation')
+          .then((s) => { if (active) setSchema(s) })
+          .catch(() => {
+            // Fallback: use combined service_equipment schema
+            getSchema('service_equipment')
+              .then((s) => { if (active) setSchema(s) })
+              .catch(() => { if (active) setSchema(null) })
+          })
       } else if (isPort) {
         getSchema('project_port')
           .then((s) => { if (active) setSchema(s) })

--- a/client/src/components/EditorPanel.tsx
+++ b/client/src/components/EditorPanel.tsx
@@ -19,11 +19,13 @@ export default function EditorPanel({ data, onChange, onSave }: EditorPanelProps
     if (file.endsWith('.yaml') || file.endsWith('.yml')) {
       const isVessel = file.includes('vessels') || file.includes('vessel') || file.includes('service_equipment')
       if (isVessel) {
+        console.log(data)
         const strategy = (data as any)?.strategy
         const strat = typeof strategy === 'string' ? strategy.toLowerCase() : ''
+        const isUnscheduled = strat === 'unscheduled' || strat === 'requests' || strat === 'downtime'
         const schemaName = strat === 'scheduled'
           ? 'service_equipment_scheduled'
-          : strat === 'unscheduled'
+          : isUnscheduled
             ? 'service_equipment_unscheduled'
             : 'service_equipment'
         getSchema(schemaName)

--- a/client/src/components/EditorPanel.tsx
+++ b/client/src/components/EditorPanel.tsx
@@ -20,6 +20,7 @@ export default function EditorPanel({ data, onChange, onSave }: EditorPanelProps
       const isVessel = file.includes('vessels') || file.includes('vessel') || file.includes('service_equipment')
       const isSubstation = file.includes('substation')
       const isTurbine = file.includes('turbine')
+      const isCable = file.includes('cable')
       const isPort = (
         file.includes('project/port') ||
         file.includes('project\\port') ||
@@ -59,6 +60,22 @@ export default function EditorPanel({ data, onChange, onSave }: EditorPanelProps
           .then((s) => { if (active) setSchema(s) })
           .catch(() => {
             const fallback = hasWrapper ? 'turbine' : 'configuration'
+            getSchema(fallback)
+              .then((s) => { if (active) setSchema(s) })
+              .catch(() => { if (active) setSchema(null) })
+          })
+      } else if (isCable) {
+        // Cable schema support; prefer wrapper when YAML has top-level capacity/capex or nested cable object
+        const hasWrapper = !!data && typeof data === 'object' && (
+          Object.prototype.hasOwnProperty.call(data as any, 'cable') ||
+          Object.prototype.hasOwnProperty.call(data as any, 'capacity_kw') ||
+          Object.prototype.hasOwnProperty.call(data as any, 'capex_kw')
+        )
+        const name = hasWrapper ? 'equipment_cable' : 'cable'
+        getSchema(name)
+          .then((s) => { if (active) setSchema(s) })
+          .catch(() => {
+            const fallback = hasWrapper ? 'cable' : 'configuration'
             getSchema(fallback)
               .then((s) => { if (active) setSchema(s) })
               .catch(() => { if (active) setSchema(null) })

--- a/client/src/components/JsonEditor.css
+++ b/client/src/components/JsonEditor.css
@@ -138,3 +138,20 @@
 .dark .json-editor .je-input::placeholder { color: #9ca3af; }
 
 /* Force light theme also uses variables; no color overrides needed */
+
+/* Error states */
+.je-input-error {
+  border-color: var(--color-danger, #dc2626);
+  box-shadow: 0 0 0 1px rgba(220, 38, 38, 0.2);
+}
+
+.je-error-text {
+  color: var(--color-danger, #dc2626);
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+.je-valid-note {
+  color: var(--color-success, #16a34a);
+  font-size: 12px;
+}

--- a/client/src/components/JsonEditor.css
+++ b/client/src/components/JsonEditor.css
@@ -117,6 +117,18 @@
   justify-self: left;
 }
 
+/* Minimal type badge for inline schema type hints */
+.je-type-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  font-size: 10px;
+  line-height: 1.4;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  border-radius: 9999px;
+}
+
 /* Dark mode is handled by CSS variables; keep placeholder readable in dark */
 @media (prefers-color-scheme: dark) {
   .json-editor .je-input::placeholder { color: #9ca3af; }

--- a/client/src/components/JsonEditor.tsx
+++ b/client/src/components/JsonEditor.tsx
@@ -19,6 +19,7 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ data, schema, onChange, onSave 
     const [formData, setFormData] = React.useState<JsonObject>(data);
     const didMountRef = React.useRef(false);
     const skipNextOnChangeRef = React.useRef(false);
+    const [errors, setErrors] = React.useState<Record<string, string[]>>({});
 
     // Sync internal state when incoming data changes
     React.useEffect(() => {
@@ -42,6 +43,156 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ data, schema, onChange, onSave 
     }, [formData]);
 
     // styles moved to JsonEditor.css
+
+    // ----------------------------
+    // Validation helpers (no AJV)
+    // ----------------------------
+    const pathToKey = (path: (string | number)[]) => path.map(String).join('.');
+
+    const pushErr = (map: Record<string, string[]>, path: (string | number)[], msg: string) => {
+        const k = pathToKey(path);
+        if (!map[k]) map[k] = [];
+        map[k].push(msg);
+    };
+
+    const isEmpty = (v: any) => v === undefined || v === null || (typeof v === 'string' && v.trim() === '');
+
+    const validateNumber = (v: any, sch: any, path: (string | number)[], out: Record<string, string[]>) => {
+        if (typeof v !== 'number' || Number.isNaN(v)) {
+            pushErr(out, path, 'Expected number');
+            return;
+        }
+        if (sch.type === 'integer' && !Number.isInteger(v)) {
+            pushErr(out, path, 'Expected integer');
+        }
+        if (typeof sch.minimum === 'number' && v < sch.minimum) pushErr(out, path, `Minimum is ${sch.minimum}`);
+        if (typeof sch.maximum === 'number' && v > sch.maximum) pushErr(out, path, `Maximum is ${sch.maximum}`);
+        if (typeof sch.exclusiveMinimum === 'number' && v <= sch.exclusiveMinimum) pushErr(out, path, `Must be > ${sch.exclusiveMinimum}`);
+        if (typeof sch.exclusiveMaximum === 'number' && v >= sch.exclusiveMaximum) pushErr(out, path, `Must be < ${sch.exclusiveMaximum}`);
+        if (typeof sch.multipleOf === 'number' && (v / sch.multipleOf) % 1 !== 0) pushErr(out, path, `Must be a multiple of ${sch.multipleOf}`);
+    };
+
+    const validateString = (v: any, sch: any, path: (string | number)[], out: Record<string, string[]>) => {
+        if (typeof v !== 'string') {
+            pushErr(out, path, 'Expected string');
+            return;
+        }
+        if (typeof sch.minLength === 'number' && v.length < sch.minLength) pushErr(out, path, `Minimum length is ${sch.minLength}`);
+        if (typeof sch.maxLength === 'number' && v.length > sch.maxLength) pushErr(out, path, `Maximum length is ${sch.maxLength}`);
+        if (typeof sch.pattern === 'string') {
+            try {
+                const re = new RegExp(sch.pattern);
+                if (!re.test(v)) pushErr(out, path, `Must match pattern ${sch.pattern}`);
+            } catch {
+                // ignore bad pattern
+            }
+        }
+    };
+
+    const validateArray = (v: any, sch: any, path: (string | number)[], out: Record<string, string[]>) => {
+        if (!Array.isArray(v)) {
+            pushErr(out, path, 'Expected array');
+            return;
+        }
+        if (typeof sch.minItems === 'number' && v.length < sch.minItems) pushErr(out, path, `At least ${sch.minItems} items required`);
+        if (typeof sch.maxItems === 'number' && v.length > sch.maxItems) pushErr(out, path, `At most ${sch.maxItems} items allowed`);
+        if (sch.uniqueItems) {
+            const seen = new Set(v.map((x: any) => JSON.stringify(x)));
+            if (seen.size !== v.length) pushErr(out, path, 'Array items must be unique');
+        }
+        if (sch.items) {
+            v.forEach((item: any, idx: number) => validateValue(item, sch.items, [...path, idx], out));
+        }
+    };
+
+    const validateObject = (v: any, sch: any, path: (string | number)[], out: Record<string, string[]>) => {
+        if (typeof v !== 'object' || v === null || Array.isArray(v)) {
+            pushErr(out, path, 'Expected object');
+            return;
+        }
+        const props = sch.properties || {};
+        const required: string[] = Array.isArray(sch.required) ? sch.required : [];
+        for (const req of required) {
+            if (isEmpty((v as any)[req])) pushErr(out, [...path, req], 'Required');
+        }
+        for (const [k, childSchema] of Object.entries<any>(props)) {
+            if ((v as any)[k] !== undefined) validateValue((v as any)[k], childSchema, [...path, k], out);
+        }
+    };
+
+    const validateEnum = (v: any, sch: any, path: (string | number)[], out: Record<string, string[]>) => {
+        if (Array.isArray(sch.enum) && !sch.enum.includes(v)) {
+            pushErr(out, path, `Must be one of: ${sch.enum.join(', ')}`);
+        }
+    };
+
+    const validateOneOf = (v: any, variants: any[], path: (string | number)[], out: Record<string, string[]>) => {
+        let anyPass = false;
+        for (const variant of variants) {
+            const tmp: Record<string, string[]> = {};
+            validateValue(v, variant, path, tmp);
+            if (Object.keys(tmp).length === 0) { anyPass = true; break; }
+        }
+        if (!anyPass) pushErr(out, path, 'Does not match any allowed schema');
+    };
+
+    const validateValue = (v: any, sch: any, path: (string | number)[], out: Record<string, string[]>) => {
+        if (!sch) return;
+        // handle union
+        if (Array.isArray(sch.oneOf) && sch.oneOf.length > 0) {
+            validateOneOf(v, sch.oneOf, path, out);
+            return;
+        }
+
+        // handle multi-type e.g., { type: ["integer", "number"] }
+        if (Array.isArray(sch.type) && sch.type.length > 0) {
+            const variants = sch.type.map((tt: any) => ({ ...sch, type: tt }));
+            validateOneOf(v, variants, path, out);
+            return;
+        }
+
+        // enum
+        if (Array.isArray(sch.enum)) validateEnum(v, sch, path, out);
+
+        const t = sch.type;
+        switch (t) {
+            case 'integer':
+            case 'number':
+                validateNumber(v, sch, path, out);
+                break;
+            case 'string':
+                validateString(v, sch, path, out);
+                break;
+            case 'boolean':
+                if (typeof v !== 'boolean') pushErr(out, path, 'Expected boolean');
+                break;
+            case 'array':
+                validateArray(v, sch, path, out);
+                break;
+            case 'object':
+                validateObject(v, sch, path, out);
+                break;
+            case 'hinst':
+                // Treat custom type 'hinst' like a string with optional pattern/min/max from schema
+                validateString(v, sch, path, out);
+                break;
+            default:
+                // If no explicit type, try to infer from subschemas
+                if (sch.properties) validateObject(v, { type: 'object', ...sch }, path, out);
+                else if (sch.items) validateArray(v, { type: 'array', ...sch }, path, out);
+        }
+    };
+
+    const validateForm = React.useCallback((value: JsonObject, sch: any | undefined) => {
+        const out: Record<string, string[]> = {};
+        if (sch) validateValue(value, sch, [], out);
+        setErrors(out);
+    }, []);
+
+    // Revalidate when data or schema changes
+    React.useEffect(() => {
+        validateForm(formData, schema);
+    }, [formData, schema, validateForm]);
 
     // Utilities to update deep values immutably
     const setDeepValue = (obj: JsonObject, path: (string | number)[], value: JsonValue): JsonObject => {
@@ -75,6 +226,7 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ data, schema, onChange, onSave 
             if (t === 'boolean') return 'bool';
             if (t === 'array') return 'arr';
             if (t === 'object') return 'obj';
+            if (t === 'hinst') return 'hinst';
         }
         if (Array.isArray(t)) return t.map((x) => String(x)).join('|');
         if (sch.oneOf) return 'union';
@@ -117,6 +269,7 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ data, schema, onChange, onSave 
         const nodeSchema = getSchemaForPath(name);
         const typeLabel = typeLabelFromSchema(nodeSchema);
         const desc = nodeSchema?.description as string | undefined;
+        const fieldErrors = errors[fieldKey] || [];
 
         // Array handling
         if (Array.isArray(value)) {
@@ -133,15 +286,28 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ data, schema, onChange, onSave 
                                         {typeof item === 'object' && item !== null ? (
                                             renderField([...name, index], item)
                                         ) : (
-                                            <input
-                                                className="je-input"
-                                                value={String(item ?? '')}
-                                                onChange={(e) => {
-                                                    const newArr = [...value];
-                                                    newArr[index] = e.target.value;
-                                                    handleChangeAtPath(name, newArr);
-                                                }}
-                                            />
+                                            (() => {
+                                                const itemKey = `${fieldKey}.${index}`;
+                                                const itemErrors = errors[itemKey] || [];
+                                                return (
+                                                    <>
+                                                        <input
+                                                            className={`je-input ${itemErrors.length ? 'je-input-error' : ''}`}
+                                                            value={String(item ?? '')}
+                                                            onChange={(e) => {
+                                                                const newArr = [...value];
+                                                                newArr[index] = e.target.value;
+                                                                handleChangeAtPath(name, newArr);
+                                                            }}
+                                                        />
+                                                        {itemErrors.length > 0 && (
+                                                            <div className="je-error-text">
+                                                                {itemErrors.map((m, i) => (<div key={i}>{m}</div>))}
+                                                            </div>
+                                                        )}
+                                                    </>
+                                                );
+                                            })()
                                         )}
                                     </div>
                                     <button
@@ -171,6 +337,11 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ data, schema, onChange, onSave 
                             >
                                 +
                             </button>
+                            {fieldErrors.length > 0 && (
+                                <div className="je-error-text">
+                                    {fieldErrors.map((m, i) => (<div key={i}>{m}</div>))}
+                                </div>
+                            )}
                         </div>
                     </details>
                 </div>
@@ -215,27 +386,50 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ data, schema, onChange, onSave 
                     <div className="je-grow">
                         <input
                             type="number"
-                            className="je-input"
+                            className={`je-input ${fieldErrors.length ? 'je-input-error' : ''}`}
                             value={Number.isFinite(value) ? String(value) : ''}
                             onChange={(e) => {
                                 const num = e.target.value === '' ? 0 : Number(e.target.value);
                                 handleChangeAtPath(name, isNaN(num) ? 0 : num);
                             }}
                         />
+                        {fieldErrors.length > 0 && (
+                            <div className="je-error-text">
+                                {fieldErrors.map((m, i) => (<div key={i}>{m}</div>))}
+                            </div>
+                        )}
                     </div>
                 ) : (
                     <div className="je-grow">
                         <input
                             type="text"
-                            className="je-input"
+                            className={`je-input ${fieldErrors.length ? 'je-input-error' : ''}`}
                             value={String(value ?? '')}
                             onChange={(e) => handleChangeAtPath(name, e.target.value)}
                         />
+                        {fieldErrors.length > 0 && (
+                            <div className="je-error-text">
+                                {fieldErrors.map((m, i) => (<div key={i}>{m}</div>))}
+                            </div>
+                        )}
                     </div>
                 )}
             </div>
         );
     };
+
+    const countNestedErrors = (prefix: string) => {
+        const p = prefix ? `${prefix}.` : '';
+        return Object.entries(errors).reduce((acc, [k, v]) => acc + (k === prefix || k.startsWith(p) ? v.length : 0), 0);
+    };
+
+    const hasErrors = Object.keys(errors).length > 0;
+    const schemaLabel = React.useMemo(() => {
+        if (!schema) return '';
+        const title = (schema && typeof schema.title === 'string') ? schema.title : '';
+        const id = (schema && typeof schema.$id === 'string') ? schema.$id : '';
+        return title || id || 'provided schema';
+    }, [schema]);
 
     return (
         <div className="json-editor json-editor-container">
@@ -245,6 +439,8 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ data, schema, onChange, onSave 
                     <button
                         type="button"
                         className="btn btn-success"
+                        disabled={hasErrors}
+                        title={hasErrors ? 'Fix validation errors before saving' : ''}
                         onClick={() => onSave?.(formData)}
                     >
                         Save
@@ -253,9 +449,17 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ data, schema, onChange, onSave 
             }
             {formData && Object.entries(formData).map(([key, value]) => (
                 <div key={key} className="je-mb-8">
-                    {renderField([key], value)}
+                    <div>
+                        {renderField([key], value)}
+                        {countNestedErrors(key) > 0 && (
+                            <div className="je-error-text je-mt-4">{countNestedErrors(key)} error(s) in this section</div>
+                        )}
+                    </div>
                 </div>
             ))}
+            {!hasErrors && schema && Object.keys(formData || {}).length > 0 && (
+                <div className="je-valid-note je-mt-8">All fields valid — checked against {schemaLabel}.</div>
+            )}
         </div>
     );
 };

--- a/client/src/components/RestClient.tsx
+++ b/client/src/components/RestClient.tsx
@@ -10,6 +10,9 @@ export default function RestClient() {
   const [baseUrl, setBaseUrl] = useState(api.apiBaseUrl)
   const [pendingPath, setPendingPath] = useState('project/config/base.yaml')
   const [pendingProjectName, setPendingProjectName] = useState('my_project')
+  const [schemas, setSchemas] = useState<string[]>([])
+  const [schemaName, setSchemaName] = useState<string>('configuration')
+  const [schemaJson, setSchemaJson] = useState<string>('')
 
   useEffect(() => {
     // Keep local input in sync if context base changes
@@ -116,6 +119,42 @@ export default function RestClient() {
             />
             <button className="btn-app btn-primary" onClick={() => api.saveLibrary(pendingProjectName)} disabled={!api.sessionId}>Save</button>
           </div>
+        </div>
+
+        <div className="ws-grid">
+          <span>Schemas</span>
+          <div className="ws-row" style={{ gap: 8 }}>
+            <button
+              className="btn-app btn-primary"
+              onClick={async () => {
+                const list = await api.listSchemas()
+                setSchemas(list)
+              }}
+            >List Schemas</button>
+            <select className="ws-input" value={schemaName} onChange={(e) => setSchemaName(e.target.value)}>
+              {[schemaName, ...schemas.filter(s => s !== schemaName)].map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+            <button
+              className="btn-app btn-secondary"
+              onClick={async () => {
+                try {
+                  const sch = await api.getSchema(schemaName)
+                  setSchemaJson(JSON.stringify(sch, null, 2))
+                } catch (e:any) {
+                  setSchemaJson(`Error: ${e?.message || String(e)}`)
+                }
+              }}
+            >Get Schema</button>
+          </div>
+          <textarea
+            className="ws-input"
+            style={{ width: '100%', height: 200 }}
+            readOnly
+            value={schemaJson}
+            placeholder="JSON Schema will appear here"
+          />
         </div>
       </div>
     </div>

--- a/client/src/hooks/useLibrary.ts
+++ b/client/src/hooks/useLibrary.ts
@@ -89,7 +89,7 @@ export function useLibrary(deps: UseLibraryDeps) {
         setLibraryFiles(wr.json?.files ?? wr.json)
         if (!workerFallbackWarned_library) {
           workerFallbackWarned_library = true
-          warning('Server unavailable. Using mock Web Worker. Some behavior may be unexpected.')
+          //warning('Server unavailable. Using mock Web Worker. Some behavior may be unexpected.')
         }
       }
     }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -168,3 +168,9 @@ html.light, html.light body, html.light #root {
   color: var(--color-text);
   background-color: var(--color-bg);
 }
+/* Ensure buttons adopt light colors when manual light mode is active */
+html.light {
+  --btn-bg: #f9f9f9;
+  --btn-fg: #111827;
+  --btn-border-color: var(--color-border);
+}

--- a/library/code_comparison/dinwoodie_slim/vessels/ctv1.yaml
+++ b/library/code_comparison/dinwoodie_slim/vessels/ctv1.yaml
@@ -7,7 +7,7 @@ end_day: 31
 start_year: 2002
 end_year: 2014
 onsite: True
-capability: CTV
+capability: ["CTV"]
 max_severity: 10
 mobilization_cost: 0
 mobilization_days: 0

--- a/library/code_comparison/dinwoodie_slim/vessels/ctv2.yaml
+++ b/library/code_comparison/dinwoodie_slim/vessels/ctv2.yaml
@@ -7,7 +7,7 @@ end_day: 31
 start_year: 2002
 end_year: 2014
 onsite: True
-capability: CTV
+capability: ["CTV"]
 max_severity: 10
 mobilization_cost: 0
 mobilization_days: 0

--- a/library/code_comparison/dinwoodie_slim/vessels/ctv3.yaml
+++ b/library/code_comparison/dinwoodie_slim/vessels/ctv3.yaml
@@ -7,7 +7,7 @@ end_day: 31
 start_year: 2002
 end_year: 2014
 onsite: True
-capability: CTV
+capability: ["CTV"]
 max_severity: 10
 mobilization_cost: 0
 mobilization_days: 0

--- a/library/code_comparison/dinwoodie_slim/vessels/ctv4.yaml
+++ b/library/code_comparison/dinwoodie_slim/vessels/ctv4.yaml
@@ -7,7 +7,7 @@ end_day: 31
 start_year: 2002
 end_year: 2014
 onsite: True
-capability: CTV
+capability: ["CTV"]
 max_severity: 10
 mobilization_cost: 0
 mobilization_days: 0

--- a/library/code_comparison/dinwoodie_slim/vessels/ctv5.yaml
+++ b/library/code_comparison/dinwoodie_slim/vessels/ctv5.yaml
@@ -7,7 +7,7 @@ end_day: 31
 start_year: 2002
 end_year: 2014
 onsite: True
-capability: CTV
+capability: ["CTV"]
 max_severity: 10
 mobilization_cost: 0
 mobilization_days: 0

--- a/library/code_comparison/dinwoodie_slim/vessels/fsv_downtime.yaml
+++ b/library/code_comparison/dinwoodie_slim/vessels/fsv_downtime.yaml
@@ -4,7 +4,7 @@ charter_days: 28
 strategy: downtime
 strategy_threshold: 0.9
 onsite: false
-capability: SCN
+capability: ["SCN"]
 mobilization_cost: 0
 mobilization_days: 21
 speed: 22.22

--- a/library/code_comparison/dinwoodie_slim/vessels/fsv_requests.yaml
+++ b/library/code_comparison/dinwoodie_slim/vessels/fsv_requests.yaml
@@ -4,7 +4,7 @@ charter_days: 28
 strategy: requests
 strategy_threshold: 3
 onsite: false
-capability: SCN
+capability: ["SCN"]
 mobilization_cost: 0
 mobilization_days: 21
 speed: 22.22

--- a/library/code_comparison/dinwoodie_slim/vessels/fsv_scheduled.yaml
+++ b/library/code_comparison/dinwoodie_slim/vessels/fsv_scheduled.yaml
@@ -7,7 +7,7 @@ end_day: 28
 start_year: 2002
 end_year: 2014
 onsite: false
-capability: SCN
+capability: ["SCN"]
 mobilization_cost: 0
 mobilization_days: 21
 speed: 22.22

--- a/library/code_comparison/dinwoodie_slim/vessels/hlv_1_scheduled.yaml
+++ b/library/code_comparison/dinwoodie_slim/vessels/hlv_1_scheduled.yaml
@@ -7,7 +7,7 @@ end_day: 15
 start_year: 2002
 end_year: 2014
 onsite: false
-capability: LCN
+capability: ["LCN"]
 mobilization_cost: 500000
 mobilization_days: 60
 speed: 12.66

--- a/library/code_comparison/dinwoodie_slim/vessels/hlv_2_scheduled.yaml
+++ b/library/code_comparison/dinwoodie_slim/vessels/hlv_2_scheduled.yaml
@@ -7,7 +7,7 @@ end_day: 15
 start_year: 2002
 end_year: 2014
 onsite: false
-capability: LCN
+capability: ["LCN"]
 mobilization_cost: 500000
 mobilization_days: 60
 speed: 12.66

--- a/library/code_comparison/dinwoodie_slim/vessels/hlv_3_scheduled.yaml
+++ b/library/code_comparison/dinwoodie_slim/vessels/hlv_3_scheduled.yaml
@@ -7,7 +7,7 @@ end_day: 15
 start_year: 2002
 end_year: 2014
 onsite: false
-capability: LCN
+capability: ["LCN"]
 mobilization_cost: 500000
 mobilization_days: 60
 speed: 12.66

--- a/library/code_comparison/dinwoodie_slim/vessels/hlv_downtime.yaml
+++ b/library/code_comparison/dinwoodie_slim/vessels/hlv_downtime.yaml
@@ -6,7 +6,7 @@ strategy_threshold: 0.9
 start_year: 2002
 end_year: 2014
 onsite: false
-capability: LCN
+capability: ["LCN"]
 mobilization_cost: 500000
 mobilization_days: 60
 speed: 12.66

--- a/library/code_comparison/dinwoodie_slim/vessels/hlv_requests.yaml
+++ b/library/code_comparison/dinwoodie_slim/vessels/hlv_requests.yaml
@@ -6,7 +6,7 @@ strategy_threshold: 3
 start_year: 2002
 end_year: 2014
 onsite: false
-capability: LCN
+capability: ["LCN"]
 mobilization_cost: 500000
 mobilization_days: 60
 speed: 12.66

--- a/server/rest_api.py
+++ b/server/rest_api.py
@@ -7,6 +7,7 @@ from server.routers import library as library_router
 from server.routers import saved as saved_router
 from server.routers import temp as temp_router
 from server.routers import simulations as simulations_router
+from server.routers import schemas as schemas_router
 
 
 router = APIRouter(prefix="/api", tags=["wombat-rest"])
@@ -17,3 +18,4 @@ router.include_router(library_router.router)
 router.include_router(saved_router.router)
 router.include_router(temp_router.router)
 router.include_router(simulations_router.router)
+router.include_router(schemas_router.router)

--- a/server/routers/schemas.py
+++ b/server/routers/schemas.py
@@ -22,6 +22,8 @@ async def list_schemas() -> dict[str, list[str]]:
             "substation",
             "turbine",
             "equipment_turbine",
+            "cable",
+            "equipment_cable",
             "project_port",
         ]
     }

--- a/server/routers/schemas.py
+++ b/server/routers/schemas.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException
 
-from wombat.utilities.schema_gen import schema_by_name, schema_service_equipment_variants, schema_configuration
+from wombat.utilities.schema_gen import (
+    schema_by_name,
+    schema_service_equipment_variants,
+)
 
 router = APIRouter(prefix="/schemas", tags=["schemas"])
 
@@ -13,8 +16,10 @@ async def list_schemas() -> dict[str, list[str]]:
         "available": [
             "configuration",
             "service_equipment",
+            "service_equipment/variants",
             "service_equipment_scheduled",
             "service_equipment_unscheduled",
+            "substation",
             "project_port",
         ]
     }
@@ -26,3 +31,12 @@ async def get_schema(name: str) -> dict:
         return schema_by_name(name)
     except KeyError as e:
         raise HTTPException(status_code=404, detail=str(e))
+
+
+@router.get("/service_equipment/variants")
+async def get_service_equipment_variants() -> dict:
+    """Return the individual and combined service equipment schemas."""
+    try:
+        return schema_service_equipment_variants()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/server/routers/schemas.py
+++ b/server/routers/schemas.py
@@ -15,6 +15,7 @@ async def list_schemas() -> dict[str, list[str]]:
             "service_equipment",
             "service_equipment_scheduled",
             "service_equipment_unscheduled",
+            "project_port",
         ]
     }
 

--- a/server/routers/schemas.py
+++ b/server/routers/schemas.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from wombat.utilities.schema_gen import schema_by_name, schema_service_equipment_variants, schema_configuration
+
+router = APIRouter(prefix="/schemas", tags=["schemas"])
+
+
+@router.get("/")
+async def list_schemas() -> dict[str, list[str]]:
+    return {
+        "available": [
+            "configuration",
+            "service_equipment",
+            "service_equipment_scheduled",
+            "service_equipment_unscheduled",
+        ]
+    }
+
+
+@router.get("/{name}")
+async def get_schema(name: str) -> dict:
+    try:
+        return schema_by_name(name)
+    except KeyError as e:
+        raise HTTPException(status_code=404, detail=str(e))

--- a/server/routers/schemas.py
+++ b/server/routers/schemas.py
@@ -20,6 +20,8 @@ async def list_schemas() -> dict[str, list[str]]:
             "service_equipment_scheduled",
             "service_equipment_unscheduled",
             "substation",
+            "turbine",
+            "equipment_turbine",
             "project_port",
         ]
     }

--- a/wombat/utilities/schema_gen.py
+++ b/wombat/utilities/schema_gen.py
@@ -14,10 +14,12 @@ Notes:
 """
 
 from typing import Any, get_origin, get_args, get_type_hints
+import typing
 import enum
 import inspect
 import sys
 import importlib
+import types
 
 try:
     import attrs
@@ -42,8 +44,8 @@ def _json_type_from_annotation(ann: Any) -> Any:
     if ann is type(None):  # noqa: E721
         return {"type": "null"}
 
-    # Union / Optional
-    if t is sys.modules.get('typing').Union or t is getattr(sys, 'UnionType', None):  # type: ignore
+    # Union / Optional (supports typing.Union and PEP 604 unions like int | float)
+    if t is getattr(typing, 'Union', None) or t is getattr(types, 'UnionType', None):  # type: ignore
         # Build subschemas for each argument
         subs = [_json_type_from_annotation(a) for a in args]
         # Try to collapse to simple multi-type when all subs are simple {"type": <primitive>}

--- a/wombat/utilities/schema_gen.py
+++ b/wombat/utilities/schema_gen.py
@@ -408,7 +408,11 @@ def schema_by_name(name: str) -> dict[str, Any]:
         return schema_service_equipment_variants()["scheduled"]
     if name in ("service_equipment_unscheduled", "vessel_unscheduled"):
         return schema_service_equipment_variants()["unscheduled"]
+    if name in ("project_port", "port"):
+        # Port configuration schema
+        from wombat.core.data_classes import PortConfig
+        return build_schema_for_attrs_class(PortConfig, title="ProjectPort")
     raise KeyError(
         "Unknown schema name. Use one of: configuration, service_equipment, "
-        "service_equipment_scheduled, service_equipment_unscheduled"
+        "service_equipment_scheduled, service_equipment_unscheduled, project_port"
     )

--- a/wombat/utilities/schema_gen.py
+++ b/wombat/utilities/schema_gen.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+"""
+Lightweight JSON Schema generator for WOMBAT's attrs-based models.
+
+Currently supports:
+- Configuration (wombat.core.simulation_api.Configuration)
+- ServiceEquipmentData variants (ScheduledServiceEquipmentData, UnscheduledServiceEquipmentData)
+
+Notes:
+- This introspects attrs classes to derive required fields, basic types, defaults.
+- It attempts to parse docstrings' Parameters section for field descriptions when available.
+- It intentionally keeps constraints minimal; can be extended to read validators and enums.
+"""
+
+from typing import Any, get_origin, get_args
+import inspect
+import sys
+
+try:
+    import attrs
+except ImportError:  # pragma: no cover
+    import attr as attrs  # type: ignore
+
+
+def _json_type_from_annotation(ann: Any) -> Any:
+    """Map Python/typing annotations to JSON Schema types.
+    Falls back to 'string' when unknown.
+    """
+    origin = get_origin(ann)
+    args = get_args(ann)
+
+    # Handle Optionals / Unions
+    if origin is None:
+        t = ann
+    else:
+        t = origin
+
+    # NoneType
+    if ann is type(None):  # noqa: E721
+        return {"type": "null"}
+
+    # Union / Optional
+    if t is sys.modules.get('typing').Union or t is getattr(sys, 'UnionType', None):  # type: ignore
+        # Build oneOf for each argument
+        subs = [_json_type_from_annotation(a) for a in args]
+        # Merge simple type arrays if possible
+        return {"oneOf": subs}
+
+    # Containers
+    if t in (list, tuple, set):
+        item_ann = args[0] if args else Any
+        return {"type": "array", "items": _json_type_from_annotation(item_ann)}
+    if t in (dict,):
+        return {"type": "object"}
+
+    # Simple builtins and common types
+    if t in (int,):
+        return {"type": "integer"}
+    if t in (float,):
+        return {"type": "number"}
+    if t in (bool,):
+        return {"type": "boolean"}
+    # paths, pathlib.Path, pandas.DataFrame etc → string as a path or ref; we keep string
+    try:
+        import pathlib  # noqa
+        if t is pathlib.Path:
+            return {"type": "string", "format": "path"}
+    except Exception:
+        pass
+
+    # Fallback
+    return {"type": "string"}
+
+
+def _parse_param_descriptions(doc: str | None) -> dict[str, str]:
+    """Very simple parser to map field names to descriptions from a Numpy-style docstring.
+
+    Looks for a 'Parameters' section and captures lines "name : type" followed by indented description lines.
+    """
+    if not doc:
+        return {}
+    lines = doc.splitlines()
+    # Find Parameters header
+    try:
+        start = next(i for i, l in enumerate(lines) if l.strip().lower().startswith('parameters'))
+    except StopIteration:
+        return {}
+
+    # Collect from start+1 until a blank line followed by a non-indented or until another section
+    descs: dict[str, str] = {}
+    i = start + 1
+    current: str | None = None
+    buf: list[str] = []
+    while i < len(lines):
+        line = lines[i]
+        if line.strip() == '':
+            # flush current paragraph if any
+            if current and buf:
+                descs[current] = ' '.join([b.strip() for b in buf]).strip()
+                current, buf = None, []
+            i += 1
+            continue
+        if not line.startswith(' '):
+            # Reached next section
+            if current and buf:
+                descs[current] = ' '.join([b.strip() for b in buf]).strip()
+            break
+        # Parameter header line e.g., "name : type"
+        if ':' in line and (line.lstrip() == line or line.startswith('    ')):
+            # new param
+            if current and buf:
+                descs[current] = ' '.join([b.strip() for b in buf]).strip()
+            left = line.strip().split(':', 1)[0]
+            current = left.split(',')[0].strip()
+            buf = []
+        else:
+            if current is not None:
+                buf.append(line)
+        i += 1
+    # final flush
+    if current and buf and current not in descs:
+        descs[current] = ' '.join([b.strip() for b in buf]).strip()
+    return descs
+
+
+def build_schema_for_attrs_class(cls: Any, *, title: str | None = None) -> dict[str, Any]:
+    """Generate a JSON Schema for an attrs-decorated class."""
+    if not hasattr(cls, "__attrs_attrs__"):
+        raise TypeError(f"Class {cls} is not an attrs class")
+
+    field_descs = _parse_param_descriptions(getattr(cls, "__doc__", None))
+
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+
+    for a in attrs.fields(cls):
+        name = a.name
+        sch = _json_type_from_annotation(a.type) if a.type is not None else {"type": "string"}
+        # default
+        default_val = None
+        NOTHING = getattr(attrs, "NOTHING", object())
+        has_default = a.default is not NOTHING
+        # Avoid Factory defaults and callables
+        if has_default and not callable(a.default) and not hasattr(a.default, "factory"):
+            try:
+                default_val = a.default  # type: ignore
+            except Exception:
+                default_val = None
+        if default_val is not None and isinstance(default_val, (int, float, str, bool)):
+            sch["default"] = default_val
+        # description
+        if name in field_descs:
+            sch["description"] = field_descs[name]
+        properties[name] = sch
+        # required if init and no default
+        if a.init and not has_default:
+            required.append(name)
+
+    schema: dict[str, Any] = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "title": title or cls.__name__,
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        schema["required"] = required
+    return schema
+
+
+# Convenience builders for known WOMBAT models
+
+def schema_configuration() -> dict[str, Any]:
+    from wombat.core.simulation_api import Configuration
+
+    return build_schema_for_attrs_class(Configuration, title="SimulationConfiguration")
+
+
+def schema_service_equipment_variants() -> dict[str, dict[str, Any]]:
+    from wombat.core.data_classes import (
+        ScheduledServiceEquipmentData,
+        UnscheduledServiceEquipmentData,
+    )
+
+    scheduled = build_schema_for_attrs_class(
+        ScheduledServiceEquipmentData, title="ServiceEquipmentScheduled"
+    )
+    unscheduled = build_schema_for_attrs_class(
+        UnscheduledServiceEquipmentData, title="ServiceEquipmentUnscheduled"
+    )
+    combined = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "ServiceEquipment",
+        "oneOf": [scheduled, unscheduled],
+    }
+    return {
+        "scheduled": scheduled,
+        "unscheduled": unscheduled,
+        "combined": combined,
+    }
+
+
+def schema_by_name(name: str) -> dict[str, Any]:
+    name = name.lower()
+    if name in ("configuration", "config"):
+        return schema_configuration()
+    if name in ("service_equipment", "vessel", "vessels"):
+        return schema_service_equipment_variants()["combined"]
+    if name in ("service_equipment_scheduled", "vessel_scheduled"):
+        return schema_service_equipment_variants()["scheduled"]
+    if name in ("service_equipment_unscheduled", "vessel_unscheduled"):
+        return schema_service_equipment_variants()["unscheduled"]
+    raise KeyError(
+        "Unknown schema name. Use one of: configuration, service_equipment, "
+        "service_equipment_scheduled, service_equipment_unscheduled"
+    )


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Schemas added for config validation

<!-- Describe your contribution here. Please include any code snippets or examples in this section. -->
## Schema validation and generation

WOMBAT_ext exposes JSON Schemas for validating configuration and library YAML/JSON files. Schemas are generated programmatically and served via the API.

- **Generator**: `wombat/utilities/schema_gen.py`
  - Builds JSON Schema (Draft 2020-12) from `attrs`-based models.
  - Maps Python/typing annotations to schema types; parses Numpy-style docstrings for field descriptions.
  - Adds simple enums when `attrs.validators.in_(...)` is present.
  - Provides pragmatic schemas for complex library files (e.g., `turbine`, `substation`, `cable`).

- **API**: `server/routers/schemas.py`
  - `GET /schemas` — lists available schema names.
  - `GET /schemas/{name}` — returns a single schema by name.
  - `GET /schemas/service_equipment/variants` — returns scheduled, unscheduled, and combined variants.

- **Available names** (from `list_schemas()`):
  - `configuration`
  - `service_equipment`
  - `service_equipment/variants`
  - `service_equipment_scheduled`
  - `service_equipment_unscheduled`
  - `substation`
  - `turbine`
  - `equipment_turbine`
  - `cable`
  - `equipment_cable`
  - `project_port`

- **Fetch examples**
  - Single schema: `curl http://127.0.0.1:8000/schemas/turbine`
  - All names: `curl http://127.0.0.1:8000/schemas`
  - Service equipment variants: `curl http://127.0.0.1:8000/schemas/service_equipment/variants`

- **Generate in Python**
  ```python
  from wombat.utilities.schema_gen import schema_by_name

  turbine_schema = schema_by_name("turbine")
  config_schema = schema_by_name("configuration")
  ```

Notes:
- Schemas are intentionally conservative and focus on structure/types. Some domain constraints may be relaxed for compatibility across libraries.
- The `configuration` schema specializes `service_equipment` to allow IDs or pairs like `[count, name]` or `[name, count]`.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [ ] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [ ] Documentation
  - [ ] Docstrings are up-to-date
  - [ ] Related `docs/` files are up-to-date, or added when necessary
  - [ ] Documentation has been rebuilt successfully
  - [ ] Examples have been updated
- [ ] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [ ] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->


## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `path/to/file.extension`
  - `method1`: What and why something was changed in one sentence or less.

## Additional supporting information

<!--Fil out at least the versions listed below and those of any packages that may be related.-->
Python version: 3.x
WOMBAT version (`wombat.__version__`): 0.x

<!--Add any other context about the problem here.-->


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->
